### PR TITLE
✨ [Feature] #4 - 헤더 알림내역 모달과 헤더 중앙 라이브알림 ui구현

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,21 +1,28 @@
 import * as S from "./Header.styled";
-
 import { useState } from "react";
 
 import { IMAGE_CONSTANTS } from "@constants/imageConstants";
 import useBoothRevenue from "./hooks/useBoothRevenue";
 import Bell from "./_components/Bell";
+import LiveNotice from "./_components/LiveNotice";
+import { dummyNotifications } from "./dummy/dummyNotifications"; // 추가
+
 const Header = () => {
   const [isReloading, setIsReloading] = useState(false);
   const { boothName, totalRevenues, error } = useBoothRevenue();
 
-  // 알림 테스트용 state
-  const [bellActive, setBellActive] = useState(true);
-  // 알림 토글 함수 (테스트용)
-  const handleBellClick = () => {
-    setBellActive((prev) => !prev);
-  };
+  // 알림 안읽음 표시 여부
+  const [hasUnread, setHasUnread] = useState(dummyNotifications.length > 0);
+  // 모달 열림 여부
+  const [modalOpen, setModalOpen] = useState(false);
 
+  const handleBellClick = () => {
+    setModalOpen((prev) => !prev);
+    // 벨 아이콘을 클릭하여 모달을 열 때만 알림을 '읽음' 처리
+    if (!modalOpen) {
+      setHasUnread(false);
+    }
+  };
   const handleReload = () => {
     if (isReloading) return;
     setIsReloading(true);
@@ -33,13 +40,20 @@ const Header = () => {
     <S.HeaderWrapper>
       <S.BoothName>{error ? "부스 이름" : boothName}</S.BoothName>
 
+      <LiveNotice />
       <S.SalesInfoWrapper>
         <S.SalesInfoText>💰 총 매출</S.SalesInfoText>
         <S.TotalSales>
           {error ? "0원" : `${formatCurrency(totalRevenues)}원`}
         </S.TotalSales>
 
-        <Bell active={bellActive} onClick={handleBellClick} />
+        <Bell
+          active={hasUnread}
+          onClick={handleBellClick}
+          modalOpen={modalOpen}
+          onCloseModal={() => setModalOpen(false)}
+          notifications={dummyNotifications}
+        />
 
         <S.ReloadButton onClick={handleReload} disabled={isReloading}>
           <S.ReloadIcon

--- a/src/components/header/_components/Bell.tsx
+++ b/src/components/header/_components/Bell.tsx
@@ -1,16 +1,56 @@
 import styled from "styled-components";
+import { useRef, useEffect } from "react";
 import { IMAGE_CONSTANTS } from "@constants/imageConstants";
+
+import BellModal from "./BellModal";
 
 interface BellProps {
   active: boolean; // 종 활성화 여부
-  onClick?: () => void;
+  onClick: () => void;
+  modalOpen: boolean;
+  notifications: { id: number; message: string }[];
+  onCloseModal: () => void; // 모달 닫기 함수 (Header로부터 받음)
 }
 
-const Bell = ({ active, onClick }: BellProps) => {
+const Bell = ({
+  active,
+  onClick,
+  modalOpen,
+  notifications,
+  onCloseModal,
+}: BellProps) => {
+  const bellWrapperRef = useRef<HTMLButtonElement>(null);
+  // BellWrapper에 대한 ref
+
+  // 모달 외부 클릭 감지 로직 (Bell 컴포넌트 내부에서 처리)
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      // bellWrapperRef.current에 클릭된 요소가 포함되어 있지 않으면 모달을 닫음
+      // 즉, 벨 아이콘과 모달 영역 '밖'을 클릭했을 때 모달이 닫힘
+      if (
+        bellWrapperRef.current &&
+        !bellWrapperRef.current.contains(event.target as Node)
+      ) {
+        onCloseModal(); // 부모로부터 받은 모달 닫기 함수 호출
+      }
+    };
+
+    if (modalOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    } else {
+      document.removeEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [modalOpen, onCloseModal]);
+
   return (
-    <BellWrapper onClick={onClick}>
-      <img src={IMAGE_CONSTANTS.BELL} />
+    <BellWrapper ref={bellWrapperRef} onClick={onClick}>
+      <img src={IMAGE_CONSTANTS.BELL} alt="알림 종 아이콘" />
       <Dot $active={active} />
+      <BellModal $active={modalOpen} notifications={notifications} />
     </BellWrapper>
   );
 };

--- a/src/components/header/_components/BellModal.styled.ts
+++ b/src/components/header/_components/BellModal.styled.ts
@@ -1,0 +1,51 @@
+import styled from "styled-components";
+
+export const BellModalWrapper = styled.div<{ $active: boolean }>`
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  z-index: 2;
+  top: 34px;
+  right: 0;
+
+  /* justify-content: center;
+  align-items: center; */
+  width: 218px;
+
+  border-radius: 3px;
+  border: solid 1px rgba(192, 192, 192, 0.5);
+  background-color: ${({ theme }) => theme.colors.Bg};
+
+  ${({ theme }) => theme.fonts.SemiBold12}
+  color: ${({ theme }) => theme.colors.Black01};
+
+  //모달 열고닫히는 애니메이션
+  transform: scale(${(props) => (props.$active ? 1 : 0)});
+  opacity: ${(props) => (props.$active ? 1 : 0)};
+  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.2s;
+
+  pointer-events: ${(props) => (props.$active ? "auto" : "none")};
+`;
+export const DefaultText = styled.div`
+  display: flex;
+  width: 100%;
+  min-height: 64px;
+  justify-content: center;
+  align-items: center;
+`;
+export const ContentsBox = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 0 13px;
+  box-sizing: border-box;
+  width: 100%;
+  height: 32px;
+  border-bottom: 1px solid rgba(192, 192, 192, 0.5);
+
+  ${({ theme }) => theme.fonts.SemiBold10}
+  color: ${({ theme }) => theme.colors.Black01};
+
+  &:last-child {
+    border-bottom: none; /* 마지막 항목은 선 없음 */
+  }
+`;

--- a/src/components/header/_components/BellModal.tsx
+++ b/src/components/header/_components/BellModal.tsx
@@ -1,0 +1,23 @@
+import * as S from "./BellModal.styled";
+
+interface BellModalProps {
+  $active: boolean;
+  notifications: { id: number; message: string }[];
+}
+
+const BellModal = ({ $active, notifications }: BellModalProps) => {
+  return (
+    // 모달 내부 클릭 시 외부 클릭으로 인식되지 않게 설정핑
+    <S.BellModalWrapper $active={$active} onClick={(e) => e.stopPropagation()}>
+      {notifications.length === 0 ? (
+        <S.DefaultText>알림이 없습니다.</S.DefaultText>
+      ) : (
+        notifications.map((n) => (
+          <S.ContentsBox key={n.id}>{n.message}</S.ContentsBox>
+        ))
+      )}
+    </S.BellModalWrapper>
+  );
+};
+
+export default BellModal;

--- a/src/components/header/_components/LiveNotice.tsx
+++ b/src/components/header/_components/LiveNotice.tsx
@@ -1,0 +1,38 @@
+import styled from "styled-components";
+import { dummyNotifications } from "../dummy/dummyNotifications"; // 추가
+import { IMAGE_CONSTANTS } from "@constants/imageConstants";
+
+const LiveNotice = () => {
+  return (
+    <Wrapper>
+      {dummyNotifications[0].message}
+      <img
+        src={IMAGE_CONSTANTS.BELL}
+        alt="종모양 아이콘"
+        style={{ width: "14px", height: "14px", display: "flex" }}
+      />
+    </Wrapper>
+  );
+};
+
+export default LiveNotice;
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  min-width: 300px;
+  height: 35px;
+
+  padding: 0 11px;
+  box-sizing: border-box;
+
+  border-radius: 20px;
+  border: 1px solid;
+  border-color: ${({ theme }) => theme.colors.Orange01};
+  ${({ theme }) => theme.fonts.SemiBold16}
+  color: ${({ theme }) => theme.colors.Black01};
+
+  gap: 4px;
+`;

--- a/src/components/header/dummy/dummyNotifications.ts
+++ b/src/components/header/dummy/dummyNotifications.ts
@@ -1,0 +1,14 @@
+export interface Notification {
+  id: number;
+  message: string;
+}
+
+export const dummyNotifications: Notification[] = [
+  { id: 1, message: "3번 테이블에서 새로운 주문이 접수되었습니다!" },
+  { id: 2, message: "3번 테이블에서 직원을 호출했습니다!" },
+  { id: 3, message: "5번 테이블에서 새로운 주문이 접수되었습니다!" },
+  { id: 4, message: "23번 테이블에서 직원을 호출했습니다!" },
+  { id: 5, message: "5번 테이블에서 직원을 호출했습니다!" },
+  { id: 6, message: "10번 테이블에서 직원을 호출했습니다!" },
+  { id: 7, message: "100번 테이블에서 직원을 호출했습니다!" },
+];


### PR DESCRIPTION
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성-->
디폴트레이아웃 헤더 알림아이콘 모달과 헤더 중앙 추후 웹소켓으로연결할 실시간 호출 알림 ui구현했습니다. 
더미 알림내역 데이터만들어서 연결했습니다. 

## 📸 Screenshot

<!-- 작업한 화면의 스크린 샷 -->
![디폴트레이아웃리팩완](https://github.com/user-attachments/assets/772d453b-9435-4f48-8f9f-a1af23a79e1e)

## 📢 Notices

<!--공용으로 사용하는 부분에 대한 설명-->

지금은 더미데이터 알림내역 정보를  props drilling으로 구현됐는데 추후 api연결할때나 한번더 리팩해서 전역관리로 돌리는 식으로 수정하겠습니다. 지금은 ui용으로 임시구현... 
## 💭 Related Issues

- #4 
