### PR TITLE
♻️ [Refactor] : 세트메뉴가 추가됨에 따라 type 재정의 및 타입 폴더 별도로 관리, 변경된 부분에 맞게 메뉴 조회하도록 실행

### DIFF
--- a/src/pages/menu/MenuPage.tsx
+++ b/src/pages/menu/MenuPage.tsx
@@ -3,11 +3,14 @@ import MenuCreateCard from "./_components/MenuCreateCard";
 import TableFeeCard from "./_components/TableFeeCard";
 import MenuCard from "./_components/MenuCard";
 import { useEffect, useState } from "react";
-import MenuService, { Menu } from "./api/MenuService";
+import MenuService from "./api/MenuService";
 import { LoadingSpinner } from "./api/LoadingSpinner";
+import { BoothMenuData, Menu, TableInfo } from "./Type/Menu_type";
+import { boothDataDummy } from "./dummy/dummydata";
+import SetMenuCard from "./_components/SetMenuCard";
 
 const MenuPage = () => {
-  const [menus, setMenus] = useState<Menu[]>([]);
+  const [boothMenuData, setBoothMenuData] = useState<BoothMenuData>();
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -15,8 +18,9 @@ const MenuPage = () => {
     try {
       setLoading(true);
       setError(null);
-      const data = await MenuService.getMenuList();
-      setMenus(data);
+      // const data = await MenuService.getMenuList();
+      // setMenus(data);
+      setBoothMenuData(boothDataDummy); // 더미 데이터 사용
     } catch (error) {
       setError("메뉴 목록을 불러오는데 실패했습니다.");
     } finally {
@@ -29,29 +33,36 @@ const MenuPage = () => {
   }, []);
 
   // 테이블 이용료 분류 (menu_category가 "테이블 이용료"인 메뉴)
-  const tableFeeMenu = menus.find(
-    (menu) => menu.menu_category === "테이블 이용료"
-  );
+  // const tableFeeMenu = menus.find(
+  //   (menu) => menu.menu_category === "테이블 이용료"
+  // );
 
-  // 테이블 이용료가 없을 때 사용할 기본 메뉴 객체
-  const defaultTableFeeMenu: Menu = {
-    id: -1,
-    menu_name: "테이블 이용료",
-    menu_price: 0,
-    menu_description: "테이블 이용료 없음",
-    menu_category: "테이블 이용료",
-    is_soldout: true,
-    menu_image: "",
+  // // 테이블 이용료가 없을 때 사용할 기본 메뉴 객체
+  // const defaultTableFeeMenu: Menu = {
+  //   menu_id: -1,
+  //   menu_name: "테이블 이용료",
+  //   menu_price: 0,
+  //   menu_description: "테이블 이용료 없음",
+  //   menu_category: "테이블 이용료",
+  //   is_selling: true,
+  //   menu_image: "",
+  // };
+
+  // 테이블 이용료 분류
+  const tableFeeMenu = boothMenuData?.table;
+
+  const defaultTableFeeMenu: TableInfo = {
+    seat_type: "테이블 이용료 없음",
+    seat_tax_person: "",
   };
 
   // 일반 메뉴 분류 (menu_category가 "테이블 이용료"가 아닌 메뉴)
-  const regularMenus = menus
-    .filter((menu) => menu.menu_category !== "테이블 이용료")
+  const regularMenus = boothMenuData?.menus
     // 카테고리 우선순위: 차지 -> 메뉴 -> 음료
     .sort((a, b) => {
       const categoryOrder = {
         차지: 0,
-        메뉴: 1,
+        메인: 1,
         음료: 2,
       };
 
@@ -67,7 +78,7 @@ const MenuPage = () => {
       // 같은 카테고리면 비싼 순서로 정렬
       return b.menu_price - a.menu_price;
     });
-
+  const setMenus = boothMenuData?.setmenus;
   if (loading) {
     return <LoadingSpinner />;
   }
@@ -80,9 +91,16 @@ const MenuPage = () => {
     <S.MenuPageWrapper>
       <S.MenuGrid>
         <MenuCreateCard onMenuChange={fetchMenus} />
-        <TableFeeCard menu={tableFeeMenu || defaultTableFeeMenu} />
-        {regularMenus.map((menu) => (
-          <MenuCard key={menu.id} menu={menu} onMenuChange={fetchMenus} />
+        <TableFeeCard table={tableFeeMenu || defaultTableFeeMenu} />
+        {regularMenus?.map((menu) => (
+          <MenuCard key={menu.menu_id} menu={menu} onMenuChange={fetchMenus} />
+        ))}
+        {setMenus?.map((setMenu) => (
+          <SetMenuCard
+            key={setMenu.set_menu_id}
+            menu={setMenu}
+            onMenuChange={fetchMenus}
+          />
         ))}
       </S.MenuGrid>
     </S.MenuPageWrapper>

--- a/src/pages/menu/Type/Menu_type.ts
+++ b/src/pages/menu/Type/Menu_type.ts
@@ -1,0 +1,36 @@
+export type TableInfo = {
+  seat_type: "person" | "table" | "테이블 이용료 없음";
+  seat_tax_person: number | string;
+};
+
+export interface Menu {
+  menu_id: number;
+  booth_id: number;
+  menu_name: string;
+  menu_description: string;
+  menu_category: string;
+  menu_price: number;
+  menu_amount: number;
+  menu_image: string;
+  is_selling?: boolean;
+  is_sold_out?: boolean;
+}
+
+export interface SetMenu {
+  set_menu_id: number;
+  booth_id: number;
+  set_category: string;
+  set_name: string;
+  set_description: string;
+  set_image: string;
+  set_price: number;
+  origin_price: number;
+  is_sold_out?: boolean;
+  menu_items: { menu_id: number; quantity: number }[];
+}
+export type BoothMenuData = {
+  booth_id: number;
+  table?: TableInfo; // 없을 수도 있음
+  menus: Menu[];
+  setmenus: SetMenu[];
+};

--- a/src/pages/menu/_components/SetMenuCard.tsx
+++ b/src/pages/menu/_components/SetMenuCard.tsx
@@ -3,15 +3,14 @@ import { IMAGE_CONSTANTS } from "@constants/imageConstants";
 import { useState } from "react";
 import MenuModal from "../../modal_test_view/_components/MenuModal";
 import MenuDeleteModal from "../../modal_test_view/_components/MenuDeleteModal";
-import { Menu } from "../Type/Menu_type";
-import MenuService from "../api/MenuService";
+import { SetMenu } from "../Type/Menu_type";
 
-interface MenuCardProps {
-  menu: Menu;
+interface SetMenuCardProps {
+  menu: SetMenu;
   onMenuChange: () => void;
 }
 
-const MenuCard = ({ menu, onMenuChange }: MenuCardProps) => {
+const SetMenuCard = ({ menu, onMenuChange }: SetMenuCardProps) => {
   const [showModal, setShowModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
 
@@ -53,11 +52,11 @@ const MenuCard = ({ menu, onMenuChange }: MenuCardProps) => {
         )}
         <S.CardContents>
           <S.CardImg>
-            {menu.menu_image ? (
-              <img src={menu.menu_image} alt={menu.menu_name} />
+            {menu.set_image ? (
+              <img src={menu.set_image} alt={menu.set_name} />
             ) : (
               <S.DefaultCardImg>
-                <img src={IMAGE_CONSTANTS.CHARACTER} alt={menu.menu_name} />
+                <img src={IMAGE_CONSTANTS.CHARACTER} alt={menu.set_name} />
               </S.DefaultCardImg>
             )}
             <S.DeleteBtn onClick={handleDeleteClick}>
@@ -70,20 +69,21 @@ const MenuCard = ({ menu, onMenuChange }: MenuCardProps) => {
               메뉴 수정
             </S.MenuEditBtn>
             <S.CardTextInner>
-              <S.CardText className="bold">{menu.menu_name}</S.CardText>
-              <S.CardText>{menu.menu_price.toLocaleString()}원</S.CardText>
+              <S.CardText className="bold">{menu.set_name}</S.CardText>
+              <S.CardText>{menu.set_price.toLocaleString()}원</S.CardText>
             </S.CardTextInner>
             <S.CardTextInner>
               <S.CardText>재고수량</S.CardText>
               <S.CardText>
-                {menu.menu_amount !== undefined ? `${menu.menu_amount}개` : "-"}
+                {/* {menu.menu_amount !== undefined ? `${menu.menu_amount}개` : "-"} */}
+                임시갯수
               </S.CardText>
             </S.CardTextInner>
           </S.CardInfo>
         </S.CardContents>
       </S.MenuCardWrapper>
 
-      {showModal && (
+      {/* {showModal && (
         <S.ModalWrapper onClick={handleCloseModal}>
           <div onClick={(e) => e.stopPropagation()}>
             <MenuModal
@@ -103,7 +103,7 @@ const MenuCard = ({ menu, onMenuChange }: MenuCardProps) => {
             />
           </div>
         </S.ModalWrapper>
-      )}
+      )} */}
 
       {showDeleteModal && (
         <MenuDeleteModal
@@ -115,4 +115,4 @@ const MenuCard = ({ menu, onMenuChange }: MenuCardProps) => {
   );
 };
 
-export default MenuCard;
+export default SetMenuCard;

--- a/src/pages/menu/_components/TableFeeCard.tsx
+++ b/src/pages/menu/_components/TableFeeCard.tsx
@@ -1,31 +1,32 @@
 import styled from "styled-components";
 import { IMAGE_CONSTANTS } from "@constants/imageConstants";
-import { Menu } from "../api/MenuService";
+import { TableInfo } from "../Type/Menu_type";
+type TableFeeCardProps = { table: TableInfo };
 
-interface TableFeeCardProps {
-  menu: Menu;
-}
-
-const TableFeeCard = ({ menu }: TableFeeCardProps) => {
+const TableFeeCard = ({ table }: TableFeeCardProps) => {
   return (
     <TableFeeCardWrapper>
-      {menu.is_soldout && (
+      {/* {!table.table && (
         <SoldOutOverlay>
           <SoldOutText>SOLD OUT</SoldOutText>
         </SoldOutOverlay>
-      )}
+      )} */}
       <CardContents>
         <CardImg>
           <img src={IMAGE_CONSTANTS.CHARACTER} alt="테이블 이용료" />
         </CardImg>
         <CardInfo>
           <CardTextInner>
-            <CardText className="bold">{menu.menu_category}</CardText>
-            <CardText>{menu.menu_price.toLocaleString()}원</CardText>
+            <CardText className="bold">{table.seat_type}</CardText>
+            {table.seat_tax_person === "" ? (
+              <CardText>{table.seat_tax_person}</CardText>
+            ) : (
+              <CardText>{table.seat_tax_person.toLocaleString()}원</CardText>
+            )}
           </CardTextInner>
           <CardTextInner>
             <CardText>기준</CardText>
-            <CardText>{menu.menu_description}</CardText>
+            <CardText>인원 수</CardText>
           </CardTextInner>
         </CardInfo>
       </CardContents>

--- a/src/pages/menu/api/MenuService.ts
+++ b/src/pages/menu/api/MenuService.ts
@@ -1,17 +1,6 @@
 import { AxiosResponse } from "axios";
 import { instance } from "../../../services/instance";
-
-export interface Menu {
-  id: number;
-  menu_name: string;
-  menu_category: string;
-  menu_price: number;
-  menu_description: string;
-  menu_image?: string | null;
-  menu_remain?: number;
-  booth_id?: number;
-  is_soldout?: boolean;
-}
+import { Menu } from "../Type/Menu_type";
 
 export interface MenuResponse {
   status: string;

--- a/src/pages/menu/dummy/dummydata.ts
+++ b/src/pages/menu/dummy/dummydata.ts
@@ -1,0 +1,55 @@
+import { BoothMenuData } from "../Type/Menu_type";
+
+export const boothDataDummy: BoothMenuData = {
+  booth_id: 1,
+  //   table: {
+  //     seat_type: "person",
+  //     seat_tax_person: 5000,
+  //   },
+  menus: [
+    {
+      menu_id: 1,
+      booth_id: 1,
+      menu_name: "스테이크 플레이트",
+      menu_description: "육즙 가득한 스테이크와 샐러드가 함께 제공됩니다.",
+      menu_category: "메인",
+      menu_price: 12000,
+      menu_amount: 100,
+      menu_image: "https://image.cdn/steak.jpg",
+      is_selling: true,
+    },
+    {
+      menu_id: 2,
+      booth_id: 1,
+      menu_name: "아이스 아메리카노",
+      menu_description: "산미와 고소함이 조화로운 시원한 아메리카노",
+      menu_category: "음료",
+      menu_price: 3500,
+      menu_amount: 123,
+      menu_image: "https://image.cdn/americano.jpg",
+      is_selling: true,
+    },
+  ],
+  setmenus: [
+    {
+      set_menu_id: 4,
+      booth_id: 1,
+      set_category: "세트",
+      set_name: "디너 세트",
+      set_description: "스테이크, 와인, 전채가 포함된 저녁 세트",
+      set_price: 47000,
+      set_image: "https://image.cdn/dinner.jpg",
+      origin_price: 70000,
+      menu_items: [
+        {
+          menu_id: 1,
+          quantity: 1,
+        },
+        {
+          menu_id: 2,
+          quantity: 2,
+        },
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성-->

- 메뉴리스트에 세트메뉴가 추가됨에 따라서 타입을 재정의하고 폴더를 타입 폴더를 별도로 관리함.
- 더미데이터를 활용하여 새로 변경된 조건으로 잘 실행 되는지 확인

## 📸 Screenshot

<!-- 작업한 화면의 스크린 샷 -->

|                 이미지                 | 
| :-------------------------------------: |
| <img src="https://github.com/user-attachments/assets/6622ae1a-fa67-454f-ad58-312878f791f2" width="300" /> 

## 📍 PR Point

<!-- 자랑하고 싶은 부분!  -->
대대적인 개편을 이뤘음..
남 코드 보는거 넘어려워 ㅡㅡ

## 📢 Notices

<!--공용으로 사용하는 부분에 대한 설명-->

## 💭 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

#15 
