### PR TITLE
[Fix] #211 - 통계 페이지 일자별 매출 유동적으로 변경

### DIFF
--- a/src/pages/dashboard/_components/DayOfMoney.tsx
+++ b/src/pages/dashboard/_components/DayOfMoney.tsx
@@ -1,40 +1,41 @@
+import React from 'react';
 import * as S from '../DashboardPage.styled';
 import { DayOfMoney } from '../_services/dashboard.types';
 
 type Props = { stat: DayOfMoney };
+
 export default function MoneyPanel({ stat }: Props) {
+  const entries = [
+    stat?.day1_revenue && stat.day1_revenue > 0
+      ? { label: '9/24', value: stat.day1_revenue }
+      : null,
+    stat?.day2_revenue && stat.day2_revenue > 0
+      ? { label: '9/25', value: stat.day2_revenue }
+      : null,
+    stat?.day3_revenue && stat.day3_revenue > 0
+      ? { label: '9/26', value: stat.day3_revenue }
+      : null,
+  ].filter(Boolean) as { label: string; value: number }[];
+
+  const hasAny = entries.length > 0;
+
   return (
     <S.MoneyPanel>
       <S.SectionTitle>일 매출 현황</S.SectionTitle>
-      {!stat?.day1_revenue && !stat?.day2_revenue && !stat?.day3_revenue ? (
-        <S.EmptyMessage>아직 영업 전입니다.</S.EmptyMessage>
-      ) : null}
-      {stat?.day1_revenue > 0 && (
-        <>
+
+      {!hasAny && <S.EmptyMessage>아직 영업 전입니다.</S.EmptyMessage>}
+
+      {entries.map((item, idx) => (
+        <React.Fragment key={item.label}>
+          {idx > 0 && <S.MoneyLine />}
+
           <S.MoneyCon>
-            <S.MoneyDay>9/24</S.MoneyDay>
-            <S.MoneyDay>{stat?.day1_revenue}원</S.MoneyDay>
+            <S.MoneyDay>{item.label}</S.MoneyDay>
+            <S.MoneyDay>{item.value}원</S.MoneyDay>
           </S.MoneyCon>
-          <S.MoneyLine />
-        </>
-      )}
-      {stat?.day2_revenue > 0 && (
-        <>
-          <S.MoneyCon>
-            <S.MoneyDay>9/25</S.MoneyDay>
-            <S.MoneyDay>{stat?.day2_revenue}원</S.MoneyDay>
-          </S.MoneyCon>
-          <S.MoneyLine />
-        </>
-      )}
-      {stat?.day3_revenue > 0 && (
-        <>
-          <S.MoneyCon>
-            <S.MoneyDay>9/26</S.MoneyDay>
-            <S.MoneyDay>{stat?.day3_revenue}원</S.MoneyDay>
-          </S.MoneyCon>
-        </>
-      )}
+        </React.Fragment>
+      ))}
+
       <S.PanelDivider />
     </S.MoneyPanel>
   );


### PR DESCRIPTION
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성-->

기존 하드 코딩한 내용 length를 판별하여, 해당 length가 0보다 크다면 사이에 들어갈 수 있도록 변경

## 💭 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

#211
